### PR TITLE
fix TypeError (no implicit conversion of nil into String)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,5 +74,5 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  config.middleware.use RackPassword::Block, auth_codes: [Rails.application.secrets.password.presence] || ['belkaops']
+  config.middleware.use RackPassword::Block, auth_codes: [Rails.application.secrets.password.presence || 'belkaops']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -74,5 +74,5 @@ Rails.application.configure do
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
 
-  config.middleware.use RackPassword::Block, auth_codes: Rails.application.secrets.password.presence || 'belkaops'
+  config.middleware.use RackPassword::Block, auth_codes: [Rails.application.secrets.password.presence] || ['belkaops']
 end


### PR DESCRIPTION
Иначе валилось.
```
TypeError (no implicit conversion of nil into String):
  rack_password (1.3) lib/rack_password.rb:65:in `include?'
  rack_password (1.3) lib/rack_password.rb:65:in `valid_code?'
  rack_password (1.3) lib/rack_password.rb:51:in `valid?'
  rack_password (1.3) lib/rack_password.rb:19:in `call'
  rack (1.6.4) lib/rack/etag.rb:24:in `call'
  rack (1.6.4) lib/rack/conditionalget.rb:25:in `call'
  rack (1.6.4) lib/rack/head.rb:13:in `call'
...
```